### PR TITLE
Set required attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bin/*
 debug.md
 templates/*
 openapi-to-json-schema
+openapi-schema.yaml
 
 # Created by https://www.toptal.com/developers/gitignore/api/go,visualstudiocode,linux,macos,windows
 # Edit at https://www.toptal.com/developers/gitignore?templates=go,visualstudiocode,linux,macos,windows

--- a/pkg/jsonschema/schema.go
+++ b/pkg/jsonschema/schema.go
@@ -23,6 +23,7 @@ type Schema struct {
 	MinProperties        int               `json:"minProperties,omitempty"`
 	MaxProperties        int               `json:"maxProperties,omitempty"`
 	Enum                 []interface{}     `json:"enum,omitempty"`
+	Required             []string          `json:"required,omitempty"`
 }
 
 func (s *Schema) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -48,4 +49,8 @@ func (s *Schema) UnmarshalJSON(unmarshal func(interface{}) error) error {
 
 	*s = Schema(raw)
 	return nil
+}
+
+func (s *Schema) IsRequired() bool {
+	return len(s.Required) > 0
 }

--- a/pkg/openapi/schema.go
+++ b/pkg/openapi/schema.go
@@ -43,7 +43,7 @@ type Schema struct {
 	MaxItems             int               `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
 	MinProperties        int               `json:"minProperties,omitempty" yaml:"minProperties,omitempty"`
 	MaxProperties        int               `json:"maxProperties,omitempty" yaml:"maxProperties,omitempty"`
-	Enum                 []interface{}     `json:"enum" yaml:"enum"`
+	Enum                 []interface{}     `json:"enum,omitempty" yaml:"enum,omitempty"`
 	Nullable             bool              `json:"nullable" yaml:"nullable"`
 	Properties           map[string]Schema `json:"properties" yaml:"properties"`
 }
@@ -149,7 +149,6 @@ func (o *OpenAPI) ConvertToJsonSchema(component string) (*jsonschema.Schema, err
 
 func convertProperty(s Schema) jsonschema.Schema {
 	property := jsonschema.Schema{
-		Type:                 []string{s.Type},
 		Title:                s.Title,
 		Description:          s.Description,
 		Default:              s.Default,
@@ -163,6 +162,11 @@ func convertProperty(s Schema) jsonschema.Schema {
 		MinProperties:        s.MinProperties,
 		MaxProperties:        s.MaxProperties,
 		Required:             []string{},
+	}
+	if s.Type != "" {
+		property.Type = []string{s.Type}
+	} else {
+		property.Type = []string{"object"}
 	}
 	if s.Nullable {
 		property.Type = append(property.Type, "null")

--- a/test-schema.yaml
+++ b/test-schema.yaml
@@ -1,0 +1,137 @@
+{
+ "$schema": "https://json-schema.org/draft/2020-12/schema",
+ "$id": "https://example.biz/schema/ytt/data-values.json",
+ "type": [
+  "object"
+ ],
+ "properties": {
+  "foo": {
+   "title": "foo",
+   "type": [
+    "object"
+   ],
+   "properties": {
+    "array_key": {
+     "title": "array_key",
+     "type": [
+      "array"
+     ],
+     "items": {
+      "type": [
+       "string"
+      ],
+      "default": "",
+      "additionalProperties": true
+     },
+     "default": [],
+     "additionalProperties": true,
+     "minItems": 3,
+     "maxItems": 4
+    },
+    "map_key": {
+     "title": "map_key",
+     "type": [
+      "object"
+     ],
+     "additionalProperties": false,
+     "minProperties": 2,
+     "maxProperties": 5
+    },
+    "max_key": {
+     "title": "max_key",
+     "type": [
+      "integer"
+     ],
+     "default": 10,
+     "additionalProperties": true,
+     "maximum": 100
+    },
+    "min_key": {
+     "title": "min_key",
+     "type": [
+      "integer"
+     ],
+     "default": 10,
+     "additionalProperties": true
+    },
+    "one_of_integers": {
+     "title": "one_of_integers",
+     "type": [
+      "integer"
+     ],
+     "default": 1,
+     "additionalProperties": true,
+     "enum": [
+      1,
+      2,
+      3
+     ]
+    },
+    "one_of_mixed": {
+     "title": "one_of_mixed",
+     "type": [
+      "",
+      "null"
+     ],
+     "default": "one",
+     "additionalProperties": true,
+     "enum": [
+      "one",
+      2,
+      3.3,
+      {}
+     ]
+    },
+    "one_of_strings": {
+     "title": "one_of_strings",
+     "type": [
+      "string"
+     ],
+     "default": "one",
+     "additionalProperties": true,
+     "enum": [
+      "one",
+      "two",
+      "three"
+     ]
+    },
+    "range_float_key": {
+     "title": "range_float_key",
+     "type": [
+      "number"
+     ],
+     "default": 2.2,
+     "additionalProperties": true,
+     "minimum": -1,
+     "maximum": 100
+    },
+    "range_key": {
+     "title": "range_key",
+     "type": [
+      "integer"
+     ],
+     "default": 10,
+     "additionalProperties": true,
+     "maximum": 100
+    },
+    "string_key": {
+     "title": "string_key",
+     "type": [
+      "string"
+     ],
+     "default": "",
+     "additionalProperties": true,
+     "minLength": 1,
+     "maxLength": 10
+    }
+   },
+   "additionalProperties": false,
+   "required": [
+    "string_key",
+    "array_key",
+    "map_key"
+   ]
+  }
+ },
+ "additionalProperties": false
+}


### PR DESCRIPTION
Sets the required attribute on the parent object, if a property has a validation set.

Eg. Strings with `minLength > 0` are considered required